### PR TITLE
Add Visual Studio requirement to building.txt

### DIFF
--- a/docs/building.txt
+++ b/docs/building.txt
@@ -4,6 +4,7 @@ git (used to check out source)
 ruby (used by substrata build scripts)
 cmake (used for substrata build)
 Python (used by LLVM build)
+Visual Studio 2022 (v17) with "Desktop Development with C++" Workload (Used by LLVM Build)
 7-Zip (If on Windows - for extracting LLVM source code)
 
 


### PR DESCRIPTION
You need visual studio to build LLVM, and most likely Qt as well.