### PR TITLE
Update running_your_own_server.htmlfrag

### DIFF
--- a/webserver_fragments/running_your_own_server.htmlfrag
+++ b/webserver_fragments/running_your_own_server.htmlfrag
@@ -8,13 +8,13 @@
 
 <p>Download the server distribution for your operating system:</p>
 <p>
-Windows - <a href="https://downloads.indigorenderer.com/dist/cyberspace/SubstrataServer_v1.2.15.7z">SubstrataServer_v1.2.15.7z</a>
+Windows - <a href="https://downloads.indigorenderer.com/dist/cyberspace/SubstrataServer_v1.4.1.7z">SubstrataServer_v1.4.1.7z</a>
 </p>
 <p>	
-MacOS - <a href="https://downloads.indigorenderer.com/dist/cyberspace/SubstrataServerMacOS_v1.2.15_x64.tar.gz">SubstrataServerMacOS_v1.2.15_x64.tar.gz</a>
+MacOS - <a href="https://downloads.indigorenderer.com/dist/cyberspace/SubstrataServerMacOS_v1.4.1_x64.tar.gz">SubstrataServerMacOS_v1.4.1_x64.tar.gz</a>
 </p>	
 <p>	
-Linux - <a href="https://downloads.indigorenderer.com/dist/cyberspace/SubstrataServer_v1.2.15.tar.gz">SubstrataServer_v1.2.15.tar.gz</a>
+Linux - <a href="https://downloads.indigorenderer.com/dist/cyberspace/SubstrataServer_v1.4.1.tar.gz">SubstrataServer_v1.4.1.tar.gz</a>
 </p>
 
 <p>Extract the contents into a convenient directory, e.g. c:/substrata_server</p>


### PR DESCRIPTION
update the version for the links to the server distribution.
change 1.2.15 to 1.4.1 for Mac, Windows, and Linux.