### PR TITLE
Avatar: restore Avaturn link in Avatar Settings dialog

### DIFF
--- a/gui_client/AvatarSettingsDialog.cpp
+++ b/gui_client/AvatarSettingsDialog.cpp
@@ -47,6 +47,7 @@ AvatarSettingsDialog::AvatarSettingsDialog(const std::string& base_dir_path_, QS
 	std::string display_str;
 
 	display_str += "<br/><a href=\"https://substrata.readyplayer.me/\">Create a ReadyPlayerMe avatar</a>.  After creating, download and select in file browser above.";
+	display_str += "<br/><a href=\"https://avaturn.me/\">Create an Avaturn avatar</a>.  After creating, download and select in file browser above.";
 
 	this->createReadyPlayerMeLabel->setText(QtUtils::toQString(display_str));
 	this->createReadyPlayerMeLabel->setOpenExternalLinks(true);


### PR DESCRIPTION
Restores the Avaturn link in Avatar Settings dialog.

- Adds https://avaturn.me/ link under ReadyPlayerMe.
- No unrelated URL/localization changes included.

**Test:**
1. Open “Avatar Settings” in the GUI.
2. Click “Create an Avaturn avatar”.
3. Browser opens https://avaturn.me/.
